### PR TITLE
split cni::plugins::dhcp::service out of ::dhcp class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,7 +8,8 @@
 
 * [`cni`](#cni): Install Container Network Interface software
 * [`cni::plugins`](#cni--plugins): Install CNI reference plugins
-* [`cni::plugins::dhcp`](#cni--plugins--dhcp): Install the cni-dhcp service
+* [`cni::plugins::dhcp`](#cni--plugins--dhcp): Install and enable the cni-dhcp service
+* [`cni::plugins::dhcp::service`](#cni--plugins--dhcp--service): Enables the the cni-dhcp service
 * [`cni::plugins::install`](#cni--plugins--install): private class
 
 ### Defined types
@@ -82,7 +83,18 @@ Default value: `undef`
 
 ### <a name="cni--plugins--dhcp"></a>`cni::plugins::dhcp`
 
-Install the cni-dhcp service
+Install and enable the cni-dhcp service
+
+### <a name="cni--plugins--dhcp--service"></a>`cni::plugins::dhcp::service`
+
+Installs the cni-dhcp systemd service and enables it to start on boot.
+
+Explicit inclusion of this class is not necessary when using the
+cni::plugins::dhcp class.
+
+This class is intended to be included directly only when it is desirable to enable
+the cni-dhcp service without managing the installation of the cni plugin
+binaries.
 
 ### <a name="cni--plugins--install"></a>`cni::plugins::install`
 

--- a/manifests/plugins/dhcp.pp
+++ b/manifests/plugins/dhcp.pp
@@ -1,24 +1,12 @@
 #
-# @summary Install the cni-dhcp service
+# @summary Install and enable the cni-dhcp service
 #
 class cni::plugins::dhcp {
   include cni::plugins
+  include cni::plugins::dhcp::service
 
   ensure_resources('cni::plugins::enable', { 'dhcp' => {} })
 
-  $epp_vars = {
-    prog => "${cni::bin_path}/dhcp",
-  }
-
-  systemd::unit_file { 'cni-dhcp.socket':
-    content => epp("${module_name}/dhcp/cni-dhcp.socket.epp"),
-  }
-  -> systemd::unit_file { 'cni-dhcp.service':
-    content => epp("${module_name}/dhcp/cni-dhcp.service.epp", $epp_vars),
-  }
-  ~> service { 'cni-dhcp':
-    ensure    => 'running',
-    enable    => true,
-    subscribe => Cni::Plugins::Enable['dhcp'],
-  }
+  # restart the service if the installed binary changes
+  Cni::Plugins::Enable['dhcp'] ~> Service['cni-dhcp']
 }

--- a/manifests/plugins/dhcp/service.pp
+++ b/manifests/plugins/dhcp/service.pp
@@ -1,0 +1,28 @@
+#
+# @summary Enables the the cni-dhcp service
+#
+# Installs the cni-dhcp systemd service and enables it to start on boot.
+#
+# Explicit inclusion of this class is not necessary when using the
+# cni::plugins::dhcp class.
+#
+# This class is intended to be included directly only when it is desirable to enable
+# the cni-dhcp service without managing the installation of the cni plugin
+# binaries.
+#
+class cni::plugins::dhcp::service {
+  $epp_vars = {
+    prog => "${cni::bin_path}/dhcp",
+  }
+
+  systemd::unit_file { 'cni-dhcp.socket':
+    content => epp("${module_name}/dhcp/cni-dhcp.socket.epp"),
+  }
+  -> systemd::unit_file { 'cni-dhcp.service':
+    content => epp("${module_name}/dhcp/cni-dhcp.service.epp", $epp_vars),
+  }
+  ~> service { 'cni-dhcp':
+    ensure => 'running',
+    enable => true,
+  }
+}


### PR DESCRIPTION
To allow the cni-dhcp service to be enabled without requiring the cni plugins binaries to be managed.